### PR TITLE
replace arrow with feather & coerce int64 to int

### DIFF
--- a/src/sos_r/kernel.py
+++ b/src/sos_r/kernel.py
@@ -330,15 +330,17 @@ R_init_statements = r'''
     }
 }
 ..read.feather <- function(filename, index=NULL) {
-    if (! suppressMessages(suppressWarnings(require("feather", quietly = TRUE)))) {
-      try(install.packages('feather', repos='https://cran.r-project.org'), silent=TRUE)
-      if (!suppressMessages(suppressWarnings(require("feather"))))
-        stop('Failed to install feather library')
+    if (! suppressMessages(suppressWarnings(require("arrow", quietly = TRUE)))) {
+      try(install.packages('arrow', repos='https://cran.r-project.org'), silent=TRUE)
+      if (!suppressMessages(suppressWarnings(require("arrow"))))
+        stop('Failed to install arrow library')
     }
-    suppressPackageStartupMessages(library(feather, quietly = TRUE))
+    suppressPackageStartupMessages(library(arrow, quietly = TRUE))
     data = as.data.frame(read_feather(filename))
     if (!is.null(index))
       rownames(data) <- index
+    for (cn in names(data)[sapply(data,is, class2="integer64")])
+      data[[cn]] <- as.integer(data[[cn]]);
     return(data)
 }
 ..sos.preview <- function(name) {


### PR DESCRIPTION
Because the **feather** package has been abandoned and the same team is developing the **arrow** package for feather files, we decided to migrate to this package.   
There is a problem in handing **int64** data coming from python to R which needed handling and coercion to built-in **int** data type in r.   
this commit **fixes** #294